### PR TITLE
Minimal demo to build a SiPixelRecHit

### DIFF
--- a/LambaAnalyzer/BuildFile
+++ b/LambaAnalyzer/BuildFile
@@ -6,6 +6,9 @@
 <use name=DataFormats/Candidate>
 <use name=CommonTools/UtilAlgos>
 <use name=TrackingTools/Records>
+<use name=Geometry/TrackerGeometryBuilder>
+<use name=PhysicsTools/TensorFlow>
+<use name=RecoLocalTracker/ClusterParameterEstimator">
 <flags EDM_PLUGIN=1>
 <export>
    <lib name=AnalysisDSD0Analyzer2>

--- a/LambaAnalyzer/BuildFile.xml
+++ b/LambaAnalyzer/BuildFile.xml
@@ -6,7 +6,9 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="TrackingTools/Records"/>
-<use name="PhysicsTools/TensorFlow" />
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="PhysicsTools/TensorFlow"/>
+<use   name="RecoLocalTracker/ClusterParameterEstimator"/>
 <flags   EDM_PLUGIN="1"/>
 <export>
   <lib   name="1"/>

--- a/LambaAnalyzer/test/local_trkeffanalyzer_MC_GeneralTracks_cfg.py
+++ b/LambaAnalyzer/test/local_trkeffanalyzer_MC_GeneralTracks_cfg.py
@@ -211,7 +211,9 @@ process.analyzer = cms.EDAnalyzer('LambdaAnalyzer',
     BeamSpot = cms.untracked.InputTag('offlineBeamSpot'),
     trackCandidates = cms.untracked.InputTag('generalTracks'),
     PixelDigiSimLinkVector = cms.InputTag("simSiPixelDigis"),
-    SimTracks = cms.InputTag("g4SimHits")
+    SimTracks = cms.InputTag("g4SimHits"),
+    pixelClusters = cms.InputTag("hltSiPixelClusters")
+
     #PixelDigiSimLinkVector = cms.InputTag("mixData","PixelDigiSimLink"),
 )
 


### PR DESCRIPTION
This compiles, runs, and appears to create a new SiPixelRecHit object from a list of pixels and the det Id of a previous hit (a pion hit, in this case).

There are at least two options for the CPE (cluster position estimator) function and I went with the most generic one, but this may not be right.

I don't really understand the ClusterRef lines but it appears to be working.  Ultimately we'll want to have a totally new collection of clusters (a mix of split and unsplit) that we feed into the track re-fitting.   

Todo:
 - Sanity check: construct a copy of a hit using the same list of pixels and see if the hit's properties are the same. Remove a pixel and see if the properties are close
 - Clean up the code and turn it into a function that takes a list of pixels and det id and returns a SiPixelRecHit
 - Look into tracking to see if SiPixelRecHits need to become TrackingRecHits for refitting
 - Implement a simple cluster spitting algorithm
 - Use the DeepCluster score to determine whether or not to split
 - Configure code to redo tracking. In the current spot in the code, run DeepCluster, and if the score is high enough, run the splitting algorithm. Add the hit (or hits, if splitting was done) to a new collection.  After the loop over vertices, re-run tracking and save the results.